### PR TITLE
Try bump to new versions

### DIFF
--- a/SqliteBenchCore.csproj
+++ b/SqliteBenchCore.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.9" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.106" />
+    <PackageReference Include="Dapper" Version="1.60.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="3.0.0-preview6.19304.10" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19128.1-Preview" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.0-pre20190628101813" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.111" />
   </ItemGroup>
 </Project>

--- a/SqliteBenchCoreProgram.cs
+++ b/SqliteBenchCoreProgram.cs
@@ -25,7 +25,7 @@ namespace SqliteBenchCore
             PerfTest("System.Data.SQLite.SqliteConnection", n => testADO(new SQLiteConnection("Data Source=:memory:"), n));
             PerfTest("System.Data.SQLite.SqliteConnection(Dapper)", n => testDapper(new SQLiteConnection("Data Source=:memory:"), n));
 
-            PerfTest("Microsoft.Data.Sqlite.SqliteConnection", n => testADO(new Microsoft.Data.Sqlite.SqliteConnection("Data Source=:memory:;Mode=Memory"), n));
+            //PerfTest("Microsoft.Data.Sqlite.SqliteConnection", n => testADO(new Microsoft.Data.Sqlite.SqliteConnection("Data Source=:memory:;Mode=Memory"), n));
 
             PerfTest("Sql Server LocalDb", n => testADO(new SqlConnection("Data Source=(LocalDb)\\MSSQLLocalDB"), n));
             PerfTest("Sql Server LocalDb(Dapper)", n => testDapper(new SqlConnection("Data Source=(LocalDb)\\MSSQLLocalDB"), n));

--- a/SqliteBenchCoreProgram.cs
+++ b/SqliteBenchCoreProgram.cs
@@ -142,7 +142,7 @@ namespace SQLiteBench
                                 var col0 = raw.sqlite3_column_int(stmt, 0);
                                 var col1 = raw.sqlite3_column_int(stmt, 1);
                                 var col2 = raw.sqlite3_column_text(stmt, 2);
-                                sum += col0 + col1 + col2.Length;
+                                sum += col0 + col1 + col2.utf8_to_string().Length;
                             }
                             else if (code == raw.SQLITE_DONE)
                             {
@@ -189,7 +189,7 @@ namespace SQLiteBench
                                 var col0 = raw.sqlite3_column_int(stmt, 0);
                                 var col1 = raw.sqlite3_column_int(stmt, 1);
                                 var col2 = raw.sqlite3_column_text(stmt, 2);
-                                sum += col0 + col1 + col2.Length;
+                                sum += col0 + col1 + col2.utf8_to_string().Length;
                             }
                             else if (code == raw.SQLITE_DONE)
                             {
@@ -237,7 +237,7 @@ namespace SQLiteBench
                                 var col0 = raw.sqlite3_column_int(stmt, 0);
                                 var col1 = raw.sqlite3_column_int(stmt, 1);
                                 var col2 = raw.sqlite3_column_text(stmt, 2);
-                                sum += col0 + col1 + col2.Length;
+                                sum += col0 + col1 + col2.utf8_to_string().Length;
                             }
                             else if (code == raw.SQLITE_DONE)
                             {


### PR DESCRIPTION
and rought first glance the 2.0 prerelease of sqlitecplraw appears slower; and sqlclient is slightly faster (and there's no meaningful difference between the microsoft. vs. system. packages)